### PR TITLE
Add offline mode caching and logging system

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,14 @@ A modern, web-based GUI for managing Homebrew packages on macOS and Linux. This 
 - **Snappy Searches**: In-memory caching and batched metadata lookups make package listing and search incredibly fast
 
 ### 🔍 Advanced Features
+- **Offline Mode**: Continue browsing cached package data when Homebrew is unavailable
 - **Orphaned Package Detection**: Identify packages that were installed as dependencies but are no longer needed
 - **Deprecated Package Alerts**: Get notified about deprecated or disabled packages
 - **Real-time Streaming**: Watch package operations in real-time with live output
 - **Sudo Integration**: Seamless handling of operations requiring administrator privileges
 - **Package Information**: Detailed information about each package including descriptions, versions, and homepages
 - **Package Dependencies View**: Explore comprehensive dependency trees for any installed package with an interactive, collapsible tree interface that highlights required and optional dependencies
+- **Comprehensive Logging**: Server-side logging for easier debugging
 
 ### 🎨 Modern Interface
 - **Dark Theme**: Beautiful dark mode interface optimized for long usage sessions
@@ -333,9 +335,9 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 - [x] **Performance Optimization**: Faster package listing and search via in-memory caching and batched metadata retrieval
   - Stores recent search results and installed package data in a short-lived cache
   - Retrieves descriptions for multiple packages in a single `brew info` call to minimize process overhead
-- [ ] **Offline Mode**: Basic functionality when Homebrew is unavailable
+- [x] **Offline Mode**: Basic functionality when Homebrew is unavailable
 - [ ] **Configuration File**: User preferences and settings persistence
-- [ ] **Logging System**: Comprehensive logging for debugging
+- [x] **Logging System**: Comprehensive logging for debugging
 - [ ] **Unit Tests**: Comprehensive test coverage
 - [ ] **Docker Support**: Containerized deployment option
 

--- a/static/styles.css
+++ b/static/styles.css
@@ -172,10 +172,16 @@ body {
   background: rgba(16, 185, 129, 0.1);
 }
 
-.activity-line .tag.error { 
-  color: var(--danger); 
-  border-color: rgba(239, 68, 68, 0.3); 
+.activity-line .tag.error {
+  color: var(--danger);
+  border-color: rgba(239, 68, 68, 0.3);
   background: rgba(239, 68, 68, 0.1);
+}
+
+.activity-line .tag.warn {
+  color: var(--warning);
+  border-color: rgba(245, 158, 11, 0.3);
+  background: rgba(245, 158, 11, 0.1);
 }
 
 .activity-line .tag.log { 


### PR DESCRIPTION
## Summary
- add rotating file logging and log brew commands and API requests
- implement disk-based cache for package data to allow offline usage
- cache package lists in the browser and serve cached views without spinner while refreshing in background

## Testing
- `python -m py_compile server.py`
- `timeout 1s python -u server.py`

------
https://chatgpt.com/codex/tasks/task_e_68a705bb5158832e85d69211196f0a73